### PR TITLE
tools: fix order of nuse_vif_netmap_init() Issue #15

### DIFF
--- a/nuse-vif-netmap.c
+++ b/nuse-vif-netmap.c
@@ -241,3 +241,4 @@ nuse_vif_netmap_init(void)
 	nuse_vif[NUSE_VIF_NETMAP] = &nuse_vif_netmap;
 	return 0;
 }
+__define_initcall(nuse_vif_netmap_init, 1);


### PR DESCRIPTION
As Isuue #15 reported, ping or Iperf can not sending or receiving packets at this commit when vif type is NETMAP, this commit can fix this problem.
