### PR TITLE
Fix rump submodule url: from git:// to https://

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "rump"]
 	path = rump
-	url = git://github.com/libos-nuse/src-netbsd.git
+	url = https://github.com/libos-nuse/src-netbsd.git
 [submodule "netmap"]
 	path = netmap
 	url = https://code.google.com/p/netmap/


### PR DESCRIPTION
GitHub dropped today its support of the `git://` protocol.
See https://github.blog/2021-09-01-improving-git-protocol-security-github/.